### PR TITLE
[codex] Reposition CV for AI engineer roles

### DIFF
--- a/deploy/godel-ai-practitioner-cv/index.html
+++ b/deploy/godel-ai-practitioner-cv/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Michał Olesiak | AI Practitioner | Godel Technologies</title>
+    <title>Michał Olesiak | AI Engineer | Quality, Reliability, Agentic Delivery</title>
     <meta
       name="description"
-      content="Futuristic English CV tailored for Godel Technologies, focused on AI-enabled SDLC, AI-first delivery, coding agents, quality engineering, and full SDLC ownership."
+      content="Futuristic English CV of Michał Olesiak, an AI engineer focused on reliable delivery, agentic workflows, quality engineering, and hands-on product execution."
     />
     <link
       rel="icon"
@@ -1163,7 +1163,7 @@
             <span class="brand-mark">MO</span>
             <span class="brand-copy">
               <strong>Michał Olesiak</strong>
-              <span>AI Practitioner for Godel</span>
+              <span>AI Engineer | Quality + Reliability</span>
             </span>
           </a>
           <button
@@ -1206,13 +1206,13 @@
       <section class="hero reveal" id="mission">
         <div class="hero-grid">
           <div class="hero-copy">
-            <div class="eyebrow">Tailored for Godel Technologies | AI-Enabled SDLC | AI-First</div>
-            <h1>AI-first delivery across the full SDLC.</h1>
+            <div class="eyebrow">AI Engineer | Agentic Delivery | Quality and Reliability</div>
+            <h1>AI engineer for reliable delivery.</h1>
             <p class="lede">
-              I work AI-first and hands-on. I use multiple coding agents across planning, coding,
-              review, testing, and refinement. At HSBC I covered greenfield work, framework setup,
-              and multi-market rollout. Since December I have also been building Paily after hours as
-              a full-stack product in a strongly agent-driven workflow.
+              I use AI hands-on across planning, coding, review, testing, and workflow automation.
+              My background combines framework creation, regulated delivery, and release confidence
+              work at HSBC with building Paily as a full-stack product in a strongly agent-driven
+              workflow.
             </p>
           </div>
 
@@ -1221,7 +1221,7 @@
             <div class="stack-list">
               <div class="stack-item">
                 <strong>Operating model</strong>
-                <span>AI-first, human-reviewed, quality-sensitive delivery.</span>
+                <span>AI-assisted, human-reviewed engineering with reliability built into delivery.</span>
               </div>
               <div class="stack-item">
                 <strong>Primary agents in use</strong>
@@ -1229,11 +1229,11 @@
               </div>
               <div class="stack-item">
                 <strong>Where I apply AI</strong>
-                <span>Planning, coding, review, white-box testing, design direction, market fit, and content workflows.</span>
+                <span>Planning, coding, review, test design, workflow automation, product discovery, and delivery refinement.</span>
               </div>
               <div class="stack-item">
-                <strong>Why Godel fit matters</strong>
-                <span>My thesis and delivery path both point toward full SDLC transformation.</span>
+                <strong>Quality and reliability lens</strong>
+                <span>Testing, release confidence, and risk reduction stay embedded in how I engineer AI-enabled systems.</span>
               </div>
             </div>
           </aside>
@@ -1312,16 +1312,16 @@
                   <span class="career-role">Senior Test Automation Engineer</span>
                 </div>
                 <p>
-                  Working in the team that builds the brand design system, I expanded AI-supported QA
-                  across requirements, documentation, manual testing, automation, and BAU. This is
-                  where I most clearly operate across the lifecycle rather than only in the testing
-                  slice.
+                  In the team behind a large-scale brand design system, I expanded AI-enabled
+                  engineering support across requirements, documentation, manual testing, automation,
+                  and BAU. The role strengthened my ability to translate product and design inputs into
+                  reliable delivery practices rather than treating quality as a downstream step.
                 </p>
                 <div class="tag-row">
-                  <span class="tag">AI-supported QA</span>
-                  <span class="tag">Brand design system</span>
+                  <span class="tag">AI-enabled engineering</span>
+                  <span class="tag">Design system delivery</span>
                   <span class="tag">Requirements to BAU</span>
-                  <span class="tag">Lifecycle coverage</span>
+                  <span class="tag">Release confidence</span>
                 </div>
               </article>
 
@@ -1332,13 +1332,16 @@
                   <span class="career-role">Founder / Builder</span>
                 </div>
                 <p>
-                  Building a full-stack product after hours in a strongly agent-driven workflow, using AI
-                  for coding, refinement, planning, market fit, and lead finding.
+                  Building a full-stack QR payments product in an agentic workflow, using AI across
+                  implementation, refinement, workflow automation, market discovery, and iterative
+                  product shaping. This is where I combine software engineering, product thinking, and
+                  reliability discipline end to end.
                 </p>
                 <div class="tag-row">
                   <span class="tag">Full-stack product</span>
-                  <span class="tag">Agent-driven workflow</span>
-                  <span class="tag">Market fit + leads</span>
+                  <span class="tag">Agentic delivery</span>
+                  <span class="tag">Workflow automation</span>
+                  <span class="tag">Reliability by design</span>
                 </div>
               </article>
 
@@ -1349,15 +1352,16 @@
                   <span class="career-role">Test Automation Engineer</span>
                 </div>
                 <p>
-                  Built design library automation from the ground up, worked on framework setup for a new
-                  brand page, and helped deliver M&amp;S Cards and M&amp;S Loans safely into more markets,
-                  including requirements definition.
+                  Built automation foundations for design libraries and customer-facing financial
+                  journeys, including framework setup, CI integration, rollout support, and
+                  requirements definition. The role established my base in delivery enablement,
+                  quality engineering, and release confidence at scale.
                 </p>
                 <div class="tag-row">
                   <span class="tag">Greenfield automation</span>
-                  <span class="tag">Framework setup</span>
-                  <span class="tag">M&amp;S Cards + Loans</span>
-                  <span class="tag">Requirements definition</span>
+                  <span class="tag">Framework creation</span>
+                  <span class="tag">Multi-market rollout</span>
+                  <span class="tag">Quality engineering</span>
                 </div>
               </article>
 
@@ -1368,8 +1372,9 @@
                   <span class="career-role">Java Developer Trainee</span>
                 </div>
                 <p>
-                  Built a delivery foundation from requirements to demo and strengthened engineering
-                  thinking before moving deeper into software quality and automation.
+                  Built a software delivery foundation from requirements to demo and strengthened
+                  engineering thinking before moving deeper into automation and quality-focused
+                  delivery.
                 </p>
                 <div class="tag-row">
                   <span class="tag">Java</span>
@@ -1403,13 +1408,13 @@
         <aside class="side-stack">
           <section class="module reveal">
             <div class="eyebrow">Current Focus</div>
-            <h2 class="module-title">AI-first delivery profile</h2>
+            <h2 class="module-title">AI Engineering Profile</h2>
             <div class="data-lines">
-              <div class="data-line"><span>Primary domain</span><span>Quality + AI-enabled delivery</span></div>
-              <div class="data-line"><span>Mindset</span><span>Full SDLC</span></div>
-              <div class="data-line"><span>Strength</span><span>Multiple coding agents hands-on</span></div>
+              <div class="data-line"><span>Primary profile</span><span>AI Engineer</span></div>
+              <div class="data-line"><span>Secondary strength</span><span>Quality, testing, reliability</span></div>
+              <div class="data-line"><span>Working style</span><span>Agentic, hands-on, human-reviewed</span></div>
               <div class="data-line"><span>Environment</span><span>Regulated + product contexts</span></div>
-              <div class="data-line"><span>Cloud familiarity</span><span>Docker / Kubernetes</span></div>
+              <div class="data-line"><span>Engineering toolkit</span><span>LLM agents, TypeScript/Java, Playwright, Docker/Kubernetes</span></div>
             </div>
           </section>
 
@@ -1441,6 +1446,13 @@
               <p>Completed Google + SGH program focused on practical AI and automation usage.</p>
             </article>
             <article class="story-card" style="margin-top: 14px;">
+              <h3>Current development</h3>
+              <ul class="list">
+                <li>AIDEAS training planned for May 2026.</li>
+                <li>Learning n8n in personal time to deepen workflow automation practice.</li>
+              </ul>
+            </article>
+            <article class="story-card" style="margin-top: 14px;">
               <h3>Languages</h3>
               <ul class="list">
                 <li>Polish: native</li>
@@ -1455,8 +1467,8 @@
       <section class="module reveal" id="portals">
         <div class="module-header">
           <div>
-            <div class="eyebrow">Portals</div>
-            <h2 class="module-title">Open the proof points that matter</h2>
+            <div class="eyebrow">Proof Points</div>
+            <h2 class="module-title">Open the engineering evidence that matters</h2>
           </div>
         </div>
 
@@ -1466,13 +1478,14 @@
               <div class="portal-icon" aria-hidden="true">P</div>
               <h3 class="portal-title">Paily</h3>
               <p>
-                My end-to-end full-stack product laboratory, built in a strongly AI-supported workflow
-                for coding, refinement, planning, market-fit exploration, and lead discovery.
+                My end-to-end full-stack product laboratory, where I use AI to accelerate coding,
+                refinement, workflow automation, and iterative product shaping while keeping
+                reliability in scope from the start.
               </p>
               <div class="portal-tags" style="margin-top: 16px;">
-                <span class="tag">Product thinking</span>
+                <span class="tag">Engineering ownership</span>
                 <span class="tag">Full-stack build</span>
-                <span class="tag">Engineering depth</span>
+                <span class="tag">Workflow automation</span>
                 <span class="tag">Real-world validation</span>
               </div>
               <span class="cta-meta">Founder / Builder</span>
@@ -1488,12 +1501,13 @@
               <div class="portal-icon" aria-hidden="true">in</div>
               <h3 class="portal-title">LinkedIn</h3>
               <p>
-                I use AI to support my LinkedIn workflow and grow technical visibility around my work,
-                with the audience now around 2.5k followers.
+                I use LinkedIn to document technical work, AI engineering experiments, and practical
+                delivery lessons, building visible engagement around engineering and quality topics.
               </p>
               <div class="portal-tags" style="margin-top: 16px;">
-                <span class="tag">Career timeline</span>
-                <span class="tag">AI-supported content workflow</span>
+                <span class="tag">Technical communication</span>
+                <span class="tag">AI engineering topics</span>
+                <span class="tag">Quality perspective</span>
                 <span class="tag">2.5k+ followers</span>
               </div>
               <span class="cta-meta">Live profile</span>
@@ -1510,7 +1524,7 @@
         <div class="module-header">
           <div>
             <div class="eyebrow">Initiatives</div>
-            <h2 class="module-title">Additional initiatives</h2>
+            <h2 class="module-title">Leadership and learning initiatives</h2>
           </div>
         </div>
 
@@ -1521,12 +1535,12 @@
               2024, preparing the sessions independently and running the upskilling track end-to-end.
             </li>
             <li>
-              Delivered global HSBC knowledge-sharing sessions on AI-supported automation, focused on
-              practical ways to use AI in quality and automation work.
+              Delivered global knowledge-sharing sessions on AI-enabled automation, focused on
+              practical ways to use AI in engineering quality and delivery work.
             </li>
             <li>
-              I use AI in my LinkedIn workflow to build technical visibility and grow the audience,
-              which helped bring the profile to around 2.5k followers.
+              Currently preparing for AIDEAS training in May 2026 and learning n8n in personal time
+              to deepen workflow automation capabilities.
             </li>
           </ul>
         </article>

--- a/docs/superpowers/plans/2026-04-04-ai-engineer-cv-repositioning.md
+++ b/docs/superpowers/plans/2026-04-04-ai-engineer-cv-repositioning.md
@@ -1,0 +1,88 @@
+# AI Engineer CV Repositioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reposition the Godel-tailored CV into a general `AI Engineer` profile with strong quality, testing, and reliability differentiation.
+
+**Architecture:** Update the source CV HTML first, then mirror the approved copy into the dedicated deploy entrypoint because Vercel serves the page from `deploy/godel-ai-practitioner-cv/`. Keep layout and interaction structure intact while rewriting metadata, hero messaging, career framing, sidebar profile blocks, and development signals. Adjust the deploy Playwright test so it asserts the new public contract.
+
+**Tech Stack:** Static HTML/CSS/JS, Playwright, `http-server`
+
+---
+
+### Task 1: Capture the approved repositioning
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-04-04-ai-engineer-cv-repositioning-design.md`
+- Create: `docs/superpowers/plans/2026-04-04-ai-engineer-cv-repositioning.md`
+
+- [ ] **Step 1: Write the design document**
+
+Describe the approved target profile, de-branding rules, section rewrites, and new learning signals.
+
+- [ ] **Step 2: Write the implementation plan**
+
+List the exact files to update plus the expected verification command.
+
+- [ ] **Step 3: Review both docs locally**
+
+Run: `sed -n '1,220p' docs/superpowers/specs/2026-04-04-ai-engineer-cv-repositioning-design.md && sed -n '1,260p' docs/superpowers/plans/2026-04-04-ai-engineer-cv-repositioning.md`
+Expected: both documents reflect the approved `AI Engineer` positioning and mention `AIDEAS` plus `n8n`.
+
+### Task 2: Rewrite the source CV copy
+
+**Files:**
+- Modify: `godel-ai-practitioner-cv.html`
+
+- [ ] **Step 1: Rewrite top metadata and hero**
+
+Replace the title, meta description, brand subtitle, hero eyebrow, hero heading, and hero lead so the page no longer targets Godel and instead presents an AI engineer with a strong reliability and quality background.
+
+- [ ] **Step 2: Rewrite the capability panel**
+
+Update the "Mission Control" items to describe operating model, AI engineering usage, quality/reliability lens, and delivery environments.
+
+- [ ] **Step 3: Reframe the experience section**
+
+Keep the dates and companies, but rewrite summaries and tags to emphasize AI-enabled engineering, delivery ownership, release confidence, and product building.
+
+- [ ] **Step 4: Reframe the sidebar and development blocks**
+
+Rename the focus section to `AI Engineering Profile`, rewrite its data points, and add a development item for planned `AIDEAS` training in May 2026 plus ongoing `n8n` learning.
+
+- [ ] **Step 5: Rewrite proof points and initiatives**
+
+Keep the Paily and LinkedIn cards, but turn them into evidence blocks for engineering ownership and technical communication. Update initiatives to highlight knowledge sharing, AI-enabled delivery practices, and self-driven learning.
+
+### Task 3: Sync the deploy entrypoint
+
+**Files:**
+- Modify: `deploy/godel-ai-practitioner-cv/index.html`
+
+- [ ] **Step 1: Mirror the approved source copy into the deploy file**
+
+Ensure the deploy entrypoint matches the source page for all changed user-facing text.
+
+- [ ] **Step 2: Spot-check for leftover brand-specific language**
+
+Run: `rg -n "Godel|AI Practitioner for Godel|Tailored for Godel" godel-ai-practitioner-cv.html deploy/godel-ai-practitioner-cv/index.html`
+Expected: no matches.
+
+### Task 4: Update verification to the new public contract
+
+**Files:**
+- Modify: `test/tests/vercel-deploy.spec.ts`
+
+- [ ] **Step 1: Update the deploy assertions**
+
+Assert the new title, brand subtitle, and hero heading that represent the public AI engineer positioning.
+
+- [ ] **Step 2: Run the targeted test**
+
+Run: `cd test && npx playwright test tests/vercel-deploy.spec.ts --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 3: Review the final diff**
+
+Run: `git diff -- docs/superpowers/specs/2026-04-04-ai-engineer-cv-repositioning-design.md docs/superpowers/plans/2026-04-04-ai-engineer-cv-repositioning.md godel-ai-practitioner-cv.html deploy/godel-ai-practitioner-cv/index.html test/tests/vercel-deploy.spec.ts`
+Expected: only approved CV repositioning, docs, and test updates are present.

--- a/docs/superpowers/specs/2026-04-04-ai-engineer-cv-repositioning-design.md
+++ b/docs/superpowers/specs/2026-04-04-ai-engineer-cv-repositioning-design.md
@@ -1,0 +1,118 @@
+# AI Engineer CV Repositioning Design
+
+## Goal
+
+Reposition `godel-ai-practitioner-cv.html` from a company-tailored "AI Practitioner for Godel" page into a more general-purpose `AI Engineer` CV for larger, structured product organizations. The new version should keep the existing visual style and most existing proof points, but it should present Michał primarily as an AI engineer with a strong secondary edge in quality, testing, and reliability.
+
+## User-Approved Direction
+
+- Base file: `godel-ai-practitioner-cv.html`
+- Primary profile: `AI Engineer`
+- Secondary strength: `quality / testing / reliability`
+- Target market: larger companies with mature engineering practices, but not narrow enterprise-only positioning
+- Branding change: remove company-specific positioning to Godel and de-brand most content
+- Learning signal to add:
+  - planned `AIDEAS` training in May 2026
+  - `n8n` learning in personal time
+
+## Design Principles
+
+### 1. Keep the proof points, change the interpretation
+
+The current page already contains useful evidence: hands-on use of coding agents, product building, lifecycle coverage, regulated delivery, framework setup, and testing depth. Those facts should remain, but they must be framed as AI engineering and delivery capability rather than as a pitch to one employer.
+
+### 2. Move from "AI-first hype" to "AI engineer with reliability discipline"
+
+The page should not read like a generic "AI enthusiast" profile. It should instead position Michał as someone who:
+
+- builds software and workflows with AI as part of normal engineering execution
+- treats testing and reliability as part of engineering, not as a separate downstream phase
+- can operate in both product and regulated contexts
+- combines delivery depth with strong quality judgment
+
+### 3. Keep quality as differentiation, not as the whole identity
+
+The strongest truthful repositioning is not to hide the quality background, but to convert it into a hiring advantage. The page should communicate:
+
+- primary identity: AI engineer
+- differentiator: unusually strong testing, release confidence, and reliability mindset
+
+## Content Changes
+
+### Top metadata and brand cluster
+
+Replace Godel-specific title, description, and brand copy with general AI engineer wording. The short brand subtitle should become role-based rather than employer-based.
+
+### Hero section
+
+Rewrite the hero to communicate:
+
+- AI engineer as the headline identity
+- practical use of AI across planning, coding, review, testing, and workflow automation
+- evidence from both product building and structured delivery environments
+
+### Mission Control panel
+
+Keep the structure, but change the content from employer-fit messaging to recruiter-facing capability messaging:
+
+- operating model
+- AI engineering usage
+- quality and reliability lens
+- delivery environments
+
+### Career section
+
+Keep the timeline and dates. Reframe each role:
+
+- HSBC roles should emphasize framework creation, delivery enablement, release confidence, lifecycle coverage, and AI-enabled engineering practices
+- Paily should be the strongest AI engineer proof point: full-stack product build, workflow automation, iterative product shaping, and reliability engineering
+- earlier roles should remain as concise foundations
+
+### Focus/profile sidebar
+
+Rename the section to `AI Engineering Profile` and make each row recruiter-readable:
+
+- primary profile
+- secondary strength
+- working style
+- environment
+- engineering toolkit
+
+### Education and development
+
+Keep formal education. Add an explicit development block for active learning:
+
+- `AIDEAS` training planned for May 2026
+- `n8n` workflow automation learning in personal time
+
+These items must be clearly labeled as planned / ongoing learning, not completed credentials.
+
+### Proof points / portals
+
+Keep Paily and LinkedIn, but rewrite them as evidence blocks:
+
+- Paily = engineering ownership and AI-supported product delivery
+- LinkedIn = technical communication and visible engagement with AI and engineering topics
+
+### Initiatives
+
+Use the initiatives section to reinforce leadership and signal practical AI adoption:
+
+- internal upskilling
+- knowledge sharing
+- AI-enabled quality and delivery practices
+- self-directed learning
+
+## Files In Scope
+
+- `godel-ai-practitioner-cv.html`
+- `deploy/godel-ai-practitioner-cv/index.html`
+- `test/tests/vercel-deploy.spec.ts`
+
+## Verification
+
+At minimum, verify:
+
+- no Godel-specific messaging remains in the deployable page
+- the deploy copy matches the source copy for the changed sections
+- the deploy Playwright test passes against the updated wording

--- a/godel-ai-practitioner-cv.html
+++ b/godel-ai-practitioner-cv.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Michał Olesiak | AI Practitioner | Godel Technologies</title>
+    <title>Michał Olesiak | AI Engineer | Quality, Reliability, Agentic Delivery</title>
     <meta
       name="description"
-      content="Futuristic English CV tailored for Godel Technologies, focused on AI-enabled SDLC, AI-first delivery, coding agents, quality engineering, and full SDLC ownership."
+      content="Futuristic English CV of Michał Olesiak, an AI engineer focused on reliable delivery, agentic workflows, quality engineering, and hands-on product execution."
     />
     <link
       rel="icon"
@@ -1163,7 +1163,7 @@
             <span class="brand-mark">MO</span>
             <span class="brand-copy">
               <strong>Michał Olesiak</strong>
-              <span>AI Practitioner for Godel</span>
+              <span>AI Engineer | Quality + Reliability</span>
             </span>
           </a>
           <button
@@ -1206,13 +1206,13 @@
       <section class="hero reveal" id="mission">
         <div class="hero-grid">
           <div class="hero-copy">
-            <div class="eyebrow">Tailored for Godel Technologies | AI-Enabled SDLC | AI-First</div>
-            <h1>AI-first delivery across the full SDLC.</h1>
+            <div class="eyebrow">AI Engineer | Agentic Delivery | Quality and Reliability</div>
+            <h1>AI engineer for reliable delivery.</h1>
             <p class="lede">
-              I work AI-first and hands-on. I use multiple coding agents across planning, coding,
-              review, testing, and refinement. At HSBC I covered greenfield work, framework setup,
-              and multi-market rollout. Since December I have also been building Paily after hours as
-              a full-stack product in a strongly agent-driven workflow.
+              I use AI hands-on across planning, coding, review, testing, and workflow automation.
+              My background combines framework creation, regulated delivery, and release confidence
+              work at HSBC with building Paily as a full-stack product in a strongly agent-driven
+              workflow.
             </p>
           </div>
 
@@ -1221,7 +1221,7 @@
             <div class="stack-list">
               <div class="stack-item">
                 <strong>Operating model</strong>
-                <span>AI-first, human-reviewed, quality-sensitive delivery.</span>
+                <span>AI-assisted, human-reviewed engineering with reliability built into delivery.</span>
               </div>
               <div class="stack-item">
                 <strong>Primary agents in use</strong>
@@ -1229,11 +1229,11 @@
               </div>
               <div class="stack-item">
                 <strong>Where I apply AI</strong>
-                <span>Planning, coding, review, white-box testing, design direction, market fit, and content workflows.</span>
+                <span>Planning, coding, review, test design, workflow automation, product discovery, and delivery refinement.</span>
               </div>
               <div class="stack-item">
-                <strong>Why Godel fit matters</strong>
-                <span>My thesis and delivery path both point toward full SDLC transformation.</span>
+                <strong>Quality and reliability lens</strong>
+                <span>Testing, release confidence, and risk reduction stay embedded in how I engineer AI-enabled systems.</span>
               </div>
             </div>
           </aside>
@@ -1312,16 +1312,16 @@
                   <span class="career-role">Senior Test Automation Engineer</span>
                 </div>
                 <p>
-                  Working in the team that builds the brand design system, I expanded AI-supported QA
-                  across requirements, documentation, manual testing, automation, and BAU. This is
-                  where I most clearly operate across the lifecycle rather than only in the testing
-                  slice.
+                  In the team behind a large-scale brand design system, I expanded AI-enabled
+                  engineering support across requirements, documentation, manual testing, automation,
+                  and BAU. The role strengthened my ability to translate product and design inputs into
+                  reliable delivery practices rather than treating quality as a downstream step.
                 </p>
                 <div class="tag-row">
-                  <span class="tag">AI-supported QA</span>
-                  <span class="tag">Brand design system</span>
+                  <span class="tag">AI-enabled engineering</span>
+                  <span class="tag">Design system delivery</span>
                   <span class="tag">Requirements to BAU</span>
-                  <span class="tag">Lifecycle coverage</span>
+                  <span class="tag">Release confidence</span>
                 </div>
               </article>
 
@@ -1332,13 +1332,16 @@
                   <span class="career-role">Founder / Builder</span>
                 </div>
                 <p>
-                  Building a full-stack product after hours in a strongly agent-driven workflow, using AI
-                  for coding, refinement, planning, market fit, and lead finding.
+                  Building a full-stack QR payments product in an agentic workflow, using AI across
+                  implementation, refinement, workflow automation, market discovery, and iterative
+                  product shaping. This is where I combine software engineering, product thinking, and
+                  reliability discipline end to end.
                 </p>
                 <div class="tag-row">
                   <span class="tag">Full-stack product</span>
-                  <span class="tag">Agent-driven workflow</span>
-                  <span class="tag">Market fit + leads</span>
+                  <span class="tag">Agentic delivery</span>
+                  <span class="tag">Workflow automation</span>
+                  <span class="tag">Reliability by design</span>
                 </div>
               </article>
 
@@ -1349,15 +1352,16 @@
                   <span class="career-role">Test Automation Engineer</span>
                 </div>
                 <p>
-                  Built design library automation from the ground up, worked on framework setup for a new
-                  brand page, and helped deliver M&amp;S Cards and M&amp;S Loans safely into more markets,
-                  including requirements definition.
+                  Built automation foundations for design libraries and customer-facing financial
+                  journeys, including framework setup, CI integration, rollout support, and
+                  requirements definition. The role established my base in delivery enablement,
+                  quality engineering, and release confidence at scale.
                 </p>
                 <div class="tag-row">
                   <span class="tag">Greenfield automation</span>
-                  <span class="tag">Framework setup</span>
-                  <span class="tag">M&amp;S Cards + Loans</span>
-                  <span class="tag">Requirements definition</span>
+                  <span class="tag">Framework creation</span>
+                  <span class="tag">Multi-market rollout</span>
+                  <span class="tag">Quality engineering</span>
                 </div>
               </article>
 
@@ -1368,8 +1372,9 @@
                   <span class="career-role">Java Developer Trainee</span>
                 </div>
                 <p>
-                  Built a delivery foundation from requirements to demo and strengthened engineering
-                  thinking before moving deeper into software quality and automation.
+                  Built a software delivery foundation from requirements to demo and strengthened
+                  engineering thinking before moving deeper into automation and quality-focused
+                  delivery.
                 </p>
                 <div class="tag-row">
                   <span class="tag">Java</span>
@@ -1403,13 +1408,13 @@
         <aside class="side-stack">
           <section class="module reveal">
             <div class="eyebrow">Current Focus</div>
-            <h2 class="module-title">AI-first delivery profile</h2>
+            <h2 class="module-title">AI Engineering Profile</h2>
             <div class="data-lines">
-              <div class="data-line"><span>Primary domain</span><span>Quality + AI-enabled delivery</span></div>
-              <div class="data-line"><span>Mindset</span><span>Full SDLC</span></div>
-              <div class="data-line"><span>Strength</span><span>Multiple coding agents hands-on</span></div>
+              <div class="data-line"><span>Primary profile</span><span>AI Engineer</span></div>
+              <div class="data-line"><span>Secondary strength</span><span>Quality, testing, reliability</span></div>
+              <div class="data-line"><span>Working style</span><span>Agentic, hands-on, human-reviewed</span></div>
               <div class="data-line"><span>Environment</span><span>Regulated + product contexts</span></div>
-              <div class="data-line"><span>Cloud familiarity</span><span>Docker / Kubernetes</span></div>
+              <div class="data-line"><span>Engineering toolkit</span><span>LLM agents, TypeScript/Java, Playwright, Docker/Kubernetes</span></div>
             </div>
           </section>
 
@@ -1441,6 +1446,13 @@
               <p>Completed Google + SGH program focused on practical AI and automation usage.</p>
             </article>
             <article class="story-card" style="margin-top: 14px;">
+              <h3>Current development</h3>
+              <ul class="list">
+                <li>AIDEAS training planned for May 2026.</li>
+                <li>Learning n8n in personal time to deepen workflow automation practice.</li>
+              </ul>
+            </article>
+            <article class="story-card" style="margin-top: 14px;">
               <h3>Languages</h3>
               <ul class="list">
                 <li>Polish: native</li>
@@ -1455,8 +1467,8 @@
       <section class="module reveal" id="portals">
         <div class="module-header">
           <div>
-            <div class="eyebrow">Portals</div>
-            <h2 class="module-title">Open the proof points that matter</h2>
+            <div class="eyebrow">Proof Points</div>
+            <h2 class="module-title">Open the engineering evidence that matters</h2>
           </div>
         </div>
 
@@ -1466,13 +1478,14 @@
               <div class="portal-icon" aria-hidden="true">P</div>
               <h3 class="portal-title">Paily</h3>
               <p>
-                My end-to-end full-stack product laboratory, built in a strongly AI-supported workflow
-                for coding, refinement, planning, market-fit exploration, and lead discovery.
+                My end-to-end full-stack product laboratory, where I use AI to accelerate coding,
+                refinement, workflow automation, and iterative product shaping while keeping
+                reliability in scope from the start.
               </p>
               <div class="portal-tags" style="margin-top: 16px;">
-                <span class="tag">Product thinking</span>
+                <span class="tag">Engineering ownership</span>
                 <span class="tag">Full-stack build</span>
-                <span class="tag">Engineering depth</span>
+                <span class="tag">Workflow automation</span>
                 <span class="tag">Real-world validation</span>
               </div>
               <span class="cta-meta">Founder / Builder</span>
@@ -1488,12 +1501,13 @@
               <div class="portal-icon" aria-hidden="true">in</div>
               <h3 class="portal-title">LinkedIn</h3>
               <p>
-                I use AI to support my LinkedIn workflow and grow technical visibility around my work,
-                with the audience now around 2.5k followers.
+                I use LinkedIn to document technical work, AI engineering experiments, and practical
+                delivery lessons, building visible engagement around engineering and quality topics.
               </p>
               <div class="portal-tags" style="margin-top: 16px;">
-                <span class="tag">Career timeline</span>
-                <span class="tag">AI-supported content workflow</span>
+                <span class="tag">Technical communication</span>
+                <span class="tag">AI engineering topics</span>
+                <span class="tag">Quality perspective</span>
                 <span class="tag">2.5k+ followers</span>
               </div>
               <span class="cta-meta">Live profile</span>
@@ -1510,7 +1524,7 @@
         <div class="module-header">
           <div>
             <div class="eyebrow">Initiatives</div>
-            <h2 class="module-title">Additional initiatives</h2>
+            <h2 class="module-title">Leadership and learning initiatives</h2>
           </div>
         </div>
 
@@ -1521,12 +1535,12 @@
               2024, preparing the sessions independently and running the upskilling track end-to-end.
             </li>
             <li>
-              Delivered global HSBC knowledge-sharing sessions on AI-supported automation, focused on
-              practical ways to use AI in quality and automation work.
+              Delivered global knowledge-sharing sessions on AI-enabled automation, focused on
+              practical ways to use AI in engineering quality and delivery work.
             </li>
             <li>
-              I use AI in my LinkedIn workflow to build technical visibility and grow the audience,
-              which helped bring the profile to around 2.5k followers.
+              Currently preparing for AIDEAS training in May 2026 and learning n8n in personal time
+              to deepen workflow automation capabilities.
             </li>
           </ul>
         </article>

--- a/test/tests/vercel-deploy.spec.ts
+++ b/test/tests/vercel-deploy.spec.ts
@@ -1,13 +1,16 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Vercel deploy target', () => {
-  test('serves the Godel entrypoint with a compact greeting button in the topbar', async ({ page }) => {
+  test('serves the AI engineer entrypoint with a compact greeting button in the topbar', async ({ page }) => {
     await page.goto('/deploy/godel-ai-practitioner-cv/');
 
-    await expect(page).toHaveTitle(/Godel Technologies/);
-    await expect(page.getByText('AI Practitioner for Godel')).toBeVisible();
+    await expect(page).toHaveTitle(/AI Engineer/);
+    await expect(page.getByText('AI Engineer | Quality + Reliability')).toBeVisible();
     await expect(
-      page.getByRole('heading', { level: 1, name: 'AI-first delivery across the full SDLC.' })
+      page.getByRole('heading', {
+        level: 1,
+        name: 'AI engineer for reliable delivery.',
+      })
     ).toBeVisible();
 
     const audio = page.locator('#greetingAudio');


### PR DESCRIPTION
## Summary
- reposition the Godel-targeted CV into a more general AI Engineer profile with quality and reliability as differentiators
- update the deploy entrypoint copy and remove remaining Godel-specific messaging from the published variant
- add the approved spec/plan docs and adjust the deploy Playwright test to the new public contract

## Test Plan
- [x] `cd test && npx playwright test`
